### PR TITLE
fix: highlight blend when `cursorline` is enabled

### DIFF
--- a/lua/import-cost/job.lua
+++ b/lua/import-cost/job.lua
@@ -27,6 +27,7 @@ function M.render_extmark(bufnr, data, extmark_id)
                 'ImportCostVirtualText',
             },
         },
+        hl_mode = 'combine',
     })
 end
 


### PR DESCRIPTION
When cursor line is enabled, the virtual text background color overrides the cursorline background color.
Before:
![image](https://user-images.githubusercontent.com/44208530/229146608-2dc9d507-bff2-43ae-a495-73988ac8568d.png)
After:
![image](https://user-images.githubusercontent.com/44208530/229146744-3e821d68-8f7d-4dc8-afb7-8c48f31e2282.png)

Great plugin btw!