### PR TITLE
refactor: use vim.g config and lazy loading

### DIFF
--- a/lua/import-cost/extmark.lua
+++ b/lua/import-cost/extmark.lua
@@ -1,7 +1,8 @@
 local M = {}
 
-local ic, job, util =
-    require 'import-cost', require 'import-cost.job', require 'import-cost.util'
+local ic = require('import-cost')
+local job = require('import-cost.job')
+local util = require('import-cost.util')
 
 local cache = {}
 
@@ -28,9 +29,9 @@ end
 
 function M.set_extmarks(bufnr)
     local path = vim.api.nvim_buf_get_name(bufnr)
-    local filetype = vim.api.nvim_buf_get_option(bufnr, 'filetype')
+    local filetype = vim.api.nvim_get_option_value('filetype', { buf = bufnr })
 
-    local cmd = { 'node', ic.script_path, path, filetype }
+    local cmd = { 'node', ic.get_script_path(), path, filetype }
 
     local job_id = vim.fn.jobstart(cmd, {
         on_stdout = function(_, stdout, _)
@@ -59,7 +60,7 @@ function M.clear_extmarks(bufnr)
         cache[bufnr] = nil
     end
 
-    vim.api.nvim_buf_clear_namespace(bufnr, ic.ns_id, 0, -1)
+    vim.api.nvim_buf_clear_namespace(bufnr, ic.get_ns_id(), 0, -1)
 end
 
 function M.delete_extmarks(bufnr)
@@ -83,7 +84,7 @@ function M.delete_extmarks(bufnr)
         then
             goto continue
         else
-            vim.api.nvim_buf_del_extmark(bufnr, ic.ns_id, data.extmark_id)
+            vim.api.nvim_buf_del_extmark(bufnr, ic.get_ns_id(), data.extmark_id)
             cache[bufnr][string] = nil
         end
 

--- a/lua/import-cost/job.lua
+++ b/lua/import-cost/job.lua
@@ -1,25 +1,25 @@
 local M = {}
 
-local ic = require 'import-cost'
-local format = ic.config.format
+local ic = require('import-cost')
 
 local job_cache = {}
 
-local format_bytes = function(bytes)
+local function format_bytes(bytes)
+    local format = ic.get_config().format
     if bytes < 1024 then
         return string.format(format.byte_format, bytes)
     end
-
     return string.format(format.kb_format, 0.0009765625 * bytes)
 end
 
 function M.render_extmark(bufnr, data, extmark_id)
+    local format = ic.get_config().format
     local line, size, gzip =
         data.line - 1, format_bytes(data.size), format_bytes(data.gzip)
 
     local virt_text = string.format(format.virtual_text, size, gzip)
 
-    return vim.api.nvim_buf_set_extmark(bufnr, ic.ns_id, line, -1, {
+    return vim.api.nvim_buf_set_extmark(bufnr, ic.get_ns_id(), line, -1, {
         id = extmark_id,
         virt_text = {
             {

--- a/plugin/import-cost.lua
+++ b/plugin/import-cost.lua
@@ -1,0 +1,11 @@
+if vim.g.loaded_import_cost then
+  return
+end
+vim.g.loaded_import_cost = 1
+
+vim.api.nvim_create_autocmd('FileType', {
+  pattern = { 'javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'svelte' },
+  callback = function(args)
+    require('import-cost').attach(args.buf)
+  end,
+})


### PR DESCRIPTION
## Summary
- Replace `setup()` with `vim.g.import_cost` configuration
- Add `plugin/import-cost.lua` with FileType autocmd for lazy attachment
- Use getter functions for shared state instead of module properties

Plugin now auto-attaches to supported filetypes without manual setup.