### PR TITLE
chore: add luarocks release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+name: ci
+on:
+  workflow_call:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: JohnnyMorganz/stylua-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: 2.1.0
+          args: --check .

--- a/.github/workflows/luarocks.yaml
+++ b/.github/workflows/luarocks.yaml
@@ -1,0 +1,21 @@
+name: luarocks
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yaml
+
+  publish:
+    needs: ci
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: nvim-neorocks/luarocks-tag-release@v7
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}

--- a/import-cost.nvim-scm-1.rockspec
+++ b/import-cost.nvim-scm-1.rockspec
@@ -1,0 +1,6 @@
+rockspec_format = '3.0'
+package = 'import-cost.nvim'
+version = 'scm-1'
+
+source = { url = 'git://github.com/barrettruth/import-cost.nvim' }
+build = { type = 'builtin' }


### PR DESCRIPTION
## Summary
- Add rockspec for luarocks publishing
- Add CI workflow for stylua formatting
- Add luarocks workflow triggered on version tags

Requires `LUAROCKS_API_KEY` secret before merging the parent PR.