### PR TITLE
build: replace prettier with biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true
+  },
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 2
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
         default = pkgs.mkShell {
           packages = [
             pkgs.just
-            pkgs.prettier
+            pkgs.biome
             pkgs.stylua
             pkgs.neovim
             pkgs.selene
@@ -35,7 +35,7 @@
         ci = pkgs.mkShell {
           packages = [
             pkgs.just
-            pkgs.prettier
+            pkgs.biome
             pkgs.stylua
             pkgs.neovim
             pkgs.selene

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 format:
     nix fmt -- --ci
     stylua --check .
-    prettier --check .
+    biome format .
 
 lint:
     git ls-files '*.lua' | xargs selene --display-style quiet


### PR DESCRIPTION
Replace Prettier with Biome in the format workflow by updating `just format`, switching the Nix dev and CI shells to `pkgs.biome`, and adding a minimal `biome.json` for the repo's supported files.

Verified with `nix develop .#ci --command just format`, `nix develop .#ci --command just lint`, and `nix develop .#ci --command just ci`.